### PR TITLE
fix: nested arrays with a single element not parsed correctly

### DIFF
--- a/lib/rb_json5/parser/array.rb
+++ b/lib/rb_json5/parser/array.rb
@@ -7,7 +7,7 @@ module RbJSON5
     end
 
     parse_rule(:array_elements) do
-      value >> (comma >> value).repeat >> comma.maybe
+      value.as(:element) >> (comma >> value.as(:element)).repeat >> comma.maybe
     end
 
     parse_rule(:non_empty_array) do
@@ -21,7 +21,8 @@ module RbJSON5
     transform_rule(empty_array: simple(:_)) { [] }
 
     transform_rule(array_elements: subtree(:elements)) do
-      elements.is_a?(Array) && elements || [elements]
+      normalized_elements = elements.is_a?(Array) && elements || [elements]
+      normalized_elements.map { |entry| entry[:element] }
     end
   end
 end

--- a/spec/rb_json5/parser/array_spec.rb
+++ b/spec/rb_json5/parser/array_spec.rb
@@ -21,4 +21,8 @@ RSpec.describe 'parser/array' do
   it 'should parse arrays with an extra comma' do
     expect(parser).to parse('[1,]', trace: true).as([1])
   end
+
+  it 'should parse nested arrays with single element' do
+    expect(parser).to parse('[[1]]', trace: true).as([[1]])
+  end
 end


### PR DESCRIPTION
There appears to be a bug in this Gem that when there is an array with just one element which is also an array, it flattens the inner array.

For example, 
* JSON5: `[[1]]`
* Actual result: `[1]`
* Expected result: `[[1]]`

This PR fixes it by marking each `value` inside the `array_elements` subtree with `:element`. This normalizes each value's subtree to a `Hash` containing the key of `:element`. It then takes the value for each `:element` to form an array when transforming `array_elements`.