### PR TITLE
Restrict CI triggers to master branch for push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adjust CI workflow to trigger only on pushes to the master branch.